### PR TITLE
feat: add ~/.local/bin to PATH

### DIFF
--- a/powershell/user_profile.ps1
+++ b/powershell/user_profile.ps1
@@ -6,6 +6,7 @@
 # $env:GIT_SSH = "C:\Windows\system32\OpenSSH\ssh.exe"
 # $env:PATH = "C:\Program Files\Git\usr\bin;"+$env:PATH   # use gnu utils
 # $env:PATH = "$home\tools;"+$env:PATH   # use gnu utils
+$env:PATH = "$env:USERPROFILE\.local\bin;" + $env:PATH
 # Measure-Command {   # 509
 #   Import-Module posh-git
 #   $omp_config = Join-Path $PSScriptRoot ".\takuya.omp.json"


### PR DESCRIPTION
## Summary
- Add `~/.local/bin` to PATH for scoop-installed tools

## Test plan
- [x] Restart PowerShell and verify PATH includes `~/.local/bin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)